### PR TITLE
Fix NTFS Mount on Android 8+ & Bliss OS

### DIFF
--- a/core/emisc.src/1
+++ b/core/emisc.src/1
@@ -18,7 +18,7 @@ while true; do
             if [ -n "$(blkid $SEL_BLK | grep "TYPE=\"vfat\"")" ]; then
             mount -t vfat -o rw "$SEL_BLK" "$PREFIX/$MOUNTP_NAME"
             elif [ -n "$(blkid $SEL_BLK | grep "TYPE=\"ntfs\"")" ]; then
-            ntfs-3g -o rw "$SEL_BLK" "$PREFIX/$MOUNTP_NAME"
+            mount.ntfs -o rw "$SEL_BLK" "$PREFIX/$MOUNTP_NAME"
             else
             mount -o loop,rw "$SEL_BLK" "$PREFIX/$MOUNTP_NAME"
             fi


### PR DESCRIPTION
bliss os doesn't have ntfs-3g so it won't mount ntfs partitions.
we can use mount.ntfs instead and it'll work on all android x86.